### PR TITLE
add protection for (on the fly) metadata generated files

### DIFF
--- a/application/controllers/federations/Manage.php
+++ b/application/controllers/federations/Manage.php
@@ -430,12 +430,12 @@ class Manage extends MY_Controller
             $IDPmembersInArrayToHtml = $this->show_element->MembersToHtml($membersInArray['IDP']);
             $SPmembersInArrayToHtml = $this->show_element->MembersToHtml($membersInArray['SP']);
             $BOTHmembersInArrayToHtml = $this->show_element->MembersToHtml($membersInArray['BOTH']);
-            $data['result']['metadata'][] = array(lang('rr_fedmetaunsingedlink'), $data['meta_link'] . " " . anchor_popup($data['meta_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
+            $data['result']['metadata'][] = array(lang('rr_fedmetaunsingedlink'), $data['meta_link'] . " " . anchor($data['meta_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"'));
             $data['result']['metadata'][] = array(lang('rr_fedmetasingedlink'), $data['meta_link_signed'] . " " . anchor_popup($data['meta_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
 
             $lexportenabled = $federation->getLocalExport();
             if ($lexportenabled === TRUE) {
-                $data['result']['metadata'][] = array(lang('rr_fedmetaexportunsingedlink'), $data['metaexport_link'] . " " . anchor_popup($data['metaexport_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
+                $data['result']['metadata'][] = array(lang('rr_fedmetaexportunsingedlink'), $data['metaexport_link'] . " " . anchor_popup($data['metaexport_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"'));
                 $data['result']['metadata'][] = array(lang('rr_fedmetaexportsingedlink'), $data['metaexport_link_signed'] . " " . anchor_popup($data['metaexport_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
             }
 

--- a/application/controllers/providers/Detail.php
+++ b/application/controllers/providers/Detail.php
@@ -522,10 +522,10 @@ class Detail extends MY_Controller {
             $srv_circle_metalink = base_url() . 'metadata/circle/' . base64url_encode($ent->getEntityId()) . '/metadata.xml';
             $srv_circle_metalink_signed = base_url() . 'signedmetadata/provider/' . base64url_encode($ent->getEntityId()) . '/metadata.xml';
             $d[++$i]['name'] = '<a name="metadata"></a>' . lang('rr_servicemetadataurl');
-            $d[$i]['value'] = '<span class="accordionButton">' . lang('rr_metadataurl') . '</span><span class="accordionContent"><br />' . $srv_metalink . '&nbsp;</span>&nbsp; ' . anchor_popup($srv_metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>');
+            $d[$i]['value'] = '<span class="accordionButton">' . lang('rr_metadataurl') . '</span><span class="accordionContent"><br />' . $srv_metalink . '&nbsp;</span>&nbsp; ' . anchor($srv_metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"');
 
             $d[++$i]['name'] = lang('rr_circleoftrust');
-            $d[$i]['value'] = '<span class="accordionButton">' . lang('rr_metadataurl') . '</span><span class="accordionContent"><br />' . $srv_circle_metalink . '&nbsp;</span>&nbsp; ' . anchor_popup($srv_circle_metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>');
+            $d[$i]['value'] = '<span class="accordionButton">' . lang('rr_metadataurl') . '</span><span class="accordionContent"><br />' . $srv_circle_metalink . '&nbsp;</span>&nbsp; ' . anchor($srv_circle_metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>', 'class="showmetadata"');
             $d[++$i]['name'] = lang('rr_circleoftrust') . '<i>(' . lang('signed') . ')</i>';
             $d[$i]['value'] = '<span class="accordionButton">' . lang('rr_metadataurl') . '</span><span class="accordionContent"><br />' . $srv_circle_metalink_signed . '&nbsp;</span>&nbsp; ' . anchor_popup($srv_circle_metalink_signed, '<img src="' . base_url() . 'images/icons/arrow.png"/>');
         }
@@ -595,11 +595,11 @@ class Detail extends MY_Controller {
                 $fedActive = $f->getFederation()->getActive();
                 if($fedActive)
                 {
-                    $federationsString .= '<li>'. $membershipDisabled .'  '.$membershipBanned . ' ' .anchor($fedlink, $f->getFederation()->getName()) . ' <span class="accordionButton">' . lang('rr_metadataurl') . ':</span><span class="accordionContent"><br />' . $metalink . '&nbsp;</span> &nbsp;&nbsp;' . anchor_popup($metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>') . '</li>';
+                    $federationsString .= '<li>'. $membershipDisabled .'  '.$membershipBanned . ' ' .anchor($fedlink, $f->getFederation()->getName()) . ' <span class="accordionButton">' . lang('rr_metadataurl') . ':</span><span class="accordionContent"><br />' . $metalink . '&nbsp;</span> &nbsp;&nbsp;' . anchor($metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"') . '</li>';
                 }
                 else
                 {
-                    $federationsString .= '<li>'.$membershipDisabled .' '.$membershipBanned.' ' .makeLabel('disabled',lang('rr_fed_inactive_full'),lang('rr_fed_inactive_full')). ' '.anchor($fedlink, $f->getFederation()->getName()) . ' <span class="accordionButton">' . lang('rr_metadataurl') . ':</span><span class="accordionContent"><br />' . $metalink . '&nbsp;</span> &nbsp;&nbsp;' . anchor_popup($metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>') . '</li>';
+                    $federationsString .= '<li>'.$membershipDisabled .' '.$membershipBanned.' ' .makeLabel('disabled',lang('rr_fed_inactive_full'),lang('rr_fed_inactive_full')). ' '.anchor($fedlink, $f->getFederation()->getName()) . ' <span class="accordionButton">' . lang('rr_metadataurl') . ':</span><span class="accordionContent"><br />' . $metalink . '&nbsp;</span> &nbsp;&nbsp;' . anchor($metalink, '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"') . '</li>';
 
                  }
             }

--- a/application/views/federation/federation_show_view.php
+++ b/application/views/federation/federation_show_view.php
@@ -46,3 +46,5 @@ if(!empty($hiddenspan))
 {
 echo $hiddenspan;
 }
+?>
+<div class="metadataresult" style="display: none"></div>

--- a/application/views/providers/detail_view.php
+++ b/application/views/providers/detail_view.php
@@ -93,5 +93,5 @@ echo '</li>';
             </div>
 
 
-
+<div class="metadataresult" style="display: none"></div>
 

--- a/js/locals-v2.js
+++ b/js/locals-v2.js
@@ -380,6 +380,49 @@ var GINIT = {
     });
 
 
+    $('a.showmetadata').click(function(){
+       var result = $("div.metadataresult");
+       var url = $(this).attr('href');
+     //  var height = window.height();
+     //  var width = window.width();
+       $.ajax({
+          type: 'GET',
+          url: url,
+          dataType: 'xml',
+          cache: true,
+          timeout: 10000,
+          success: function(data) {
+                $('#spinner').hide();
+            var xmlstr = data.xml ? data.xml : (new XMLSerializer()).serializeToString(data);
+            result.text(xmlstr).append('<p><input type="button" value="Close" class="simplemodal-close" /></p>').modal({
+                  containerCss: {
+                      padding: 5,
+                     width: 800,
+                    }, 
+                   maxHeight: 800,
+                   closeHTML: "<a href='#' title='Close' class='modal-close'>x</a>",
+                   position: ["10%", ],
+                   overlayId: 'simpledialog-overlay',
+                   minHeight: '500',
+                   minWidth: '500',
+                   containerId: 'simpledialog-container',
+                   onShow: function(dialog) {
+                        var modal = this;
+                   }
+
+            }); 
+          },
+         beforeSend: function(){
+           result.text('');
+           $('#spinner').show();
+         },  
+         error: function(jqXHR, textStatus, errorThrown){
+           $('#spinner').hide();
+           alert(jqXHR.responseText);
+        },
+       });
+       return false;
+    });
     $('a#editprovider').click(function(e){
        //alert(window.location);
        var curTabID = $('#providertabs .ui-tabs-panel[aria-hidden="false"]').prop('id');

--- a/styles/default.css
+++ b/styles/default.css
@@ -2673,6 +2673,11 @@ ol.group li {
   max-width: 300px;
 }
 
+.metadataresult {
+  font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+  font-size: small;
+}
+
 form {
   counter-reset: fieldsets;
   background: #93aedf;

--- a/styles/orange.css
+++ b/styles/orange.css
@@ -2673,6 +2673,11 @@ ol.group li {
   max-width: 300px;
 }
 
+.metadataresult {
+  font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+  font-size: small;
+}
+
 form {
   counter-reset: fieldsets;
   background: #ffe90d;

--- a/styles/red.css
+++ b/styles/red.css
@@ -2673,6 +2673,11 @@ ol.group li {
   max-width: 300px;
 }
 
+.metadataresult {
+  font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+  font-size: small;
+}
+
 form {
   counter-reset: fieldsets;
   background: #6b90d4;

--- a/theme3/sass/partials/_page.scss
+++ b/theme3/sass/partials/_page.scss
@@ -2303,3 +2303,7 @@ ol.group {
    max-width: 300px;
 
 }
+.metadataresult {
+  font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+  font-size: small;
+}


### PR DESCRIPTION
by default all request  to unsigned metadatas (federation, circle, federationexport) which are generated on the fly are allowed.
you can limit that by adding below (optional) option into config_rr.php
$config['unsignedmeta_iplimits'] = array('IP1','IP2','IPn');
this option is set then  it must contain array of all allowed iPs (IPv4,IPv6) .  you might need to add ips of clients which are server as metadata signer/validator etc
Access to these metadas are allowed within web interface (ajax)

Access to service (sibgle entity) metadatas is not protected by that option as it can break external metadata validator .
