### PR TITLE
add support to generate EntityDescriptor ID on the fly closes #71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ application/libraries/geshi/*
 
 application/libraries/third_party/*
 
+application/helpers/custom_helper.php
 application/logs/*
 application/cache/*
 application/models/Proxies/*

--- a/application/controllers/Metadata.php
+++ b/application/controllers/Metadata.php
@@ -357,7 +357,7 @@ class Metadata extends MY_Controller
         if (!empty($disable_extcirclemeta) && $disable_extcirclemeta === TRUE) {
             $is_local = $me->getLocal();
             if (!$is_local) {
-                log_message('info', ' WARNING: cannot generate circle metadata for external provider:' . $me->getEntityId());
+                log_message('warning', 'Cannot generate circle metadata for external provider:' . $me->getEntityId());
                 log_message('debug', 'To enable generate circle metadata for external entities please set disable_extcirclemeta in config to FALSE');
                 show_error($me->getEntityId() . ': This is external provider. Cannot generate circle metadata', 403);
                 return;

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -81,6 +81,12 @@ class MY_Controller extends CI_Controller {
         }
 
         self::$langselect = languagesCodes($this->config->item('langselectlimit')); 
+
+        if(file_exists(APPPATH.'helpers/custom_helper.php'))
+        {
+          $this->load->helper('custom');
+          log_message('debug',__METHOD__.' custom_helper loaded');
+        }
     }
     public static function getLang()
     {

--- a/application/models/Provider.php
+++ b/application/models/Provider.php
@@ -3482,6 +3482,16 @@ class Provider {
 
 
         $EntityDesc_Node->setAttribute('entityID', $this->getEntityId());
+        if( $this->is_local && function_exists('customGenerateEntityDescriptorID'))
+        {
+            $cid = customGenerateEntityDescriptorID(array('id'=>''.$this->getId().'','entityid'=>''.$this->getEntityId().''));
+            if(!empty($cid))
+            {
+
+                $EntityDesc_Node->setAttribute('ID',$cid);
+            }
+         
+        }
         $ci = & get_instance();
         if (!empty($this->registrar))
         {


### PR DESCRIPTION
closes #71

right now onthefly value can be generated (for local managed entities) using custom function:

you need:
create file valid php file "custom_helper.php" in application/helpers
this file is loaded dynamically if found

in this file you need to create function customGenerateEntityDescriptorID : 
### 

function  customGenerateEntityDescriptorID($arg)
{
   /**
    \* some code
   */
  return $result;
}
### 

this function receivers $arg as array : 
$arg = array(
         'id'=>ID_OF_ENTITY_FROM_DB,
         'entityid'=>'ENTITYID'
)

I thinks ti's enough information to generate id
