### PR TITLE
Modifications to the validator

### DIFF
--- a/application/controllers/federations/Fvalidator.php
+++ b/application/controllers/federations/Fvalidator.php
@@ -250,7 +250,7 @@ class Fvalidator extends MY_Controller
                     log_message('debug', __METHOD__ . ' value for ' . $v . ' element: ' . $g);
                     if (!empty($g))
                     {
-                        $result['message'][$v] = htmlspecialchars($g);
+                        $result['message'][$v][] = htmlspecialchars($g);
                     }
                 }
             }

--- a/js/locals-v4.js
+++ b/js/locals-v4.js
@@ -665,7 +665,7 @@ var GINIT = {
                 url: url,
                 cache: false,
                 data: str,
-                timeout: 10000,
+                timeout: 120000,
                 success: function(json) {
                     $('#spinner').hide();
                     var data = $.parseJSON(json);

--- a/js/locals-v4.js
+++ b/js/locals-v4.js
@@ -684,8 +684,10 @@ var GINIT = {
                         {
                             var msgdata;
                             $.each(data.message, function(i, v) {
-                                msgdata = '<div>' + i + ': ' + v + '</div>';
-                                $("div#fvmessages").append(msgdata);
+                                $.each(v, function(j, m) {
+                                        msgdata = '<div>' + i + ': ' + m + '</div>';
+                                        $("div#fvmessages").append(msgdata);
+                                });
                             });
 
                         }


### PR DESCRIPTION
Two different commits are part of this pull request:
- The first commit modifies the timeout for validator ajax call (set to 2 minutes). Many validators (like the Shibboleth MDA for instance) require longer time to finish the validation process.
- The second commit modifies the validator output so that different messages can be shown to the users.
  The result of a validation step for some metadata may result in different messages to be shown to the users (different errors or warnings may be raised by the validation process).
  To implement this modification, the validator class has been modified to parse the XML, retrieve all tags with the specified names for the messages, and append them to a JSON array.
  Then the locals-v4.js has been modified to show all the elements of the message array to different DIVs on the webpage shown to the user on Jagger.
