### PR TITLE
Make configurable the minimum username lenght

### DIFF
--- a/application/config/config_rr-default.php
+++ b/application/config/config_rr-default.php
@@ -70,6 +70,10 @@ $config['autoregister_federated'] = false;
  * Member has read access to most pages
  */
 $config['register_defaultrole'] = 'Guest';
+/**
+ * Defines the minimum allowed length of a username
+ */
+$config['username_min_length'] = 5;
 /** 
  * make sure that all Shib_required are mapped
  * 

--- a/application/controllers/manage/Users.php
+++ b/application/controllers/manage/Users.php
@@ -41,7 +41,8 @@ class Users extends MY_Controller {
     }
     private function _add_submit_validate() {
         log_message('debug',  '(add user) validating form initialized');
-        $this->form_validation->set_rules('username', ''.lang('rr_username').'', 'required|min_length[5]|max_length[128]|user_username_unique[username]|xss_clean');
+        $usernameMinLength = $this->config->item('username_min_length');
+        $this->form_validation->set_rules('username', ''.lang('rr_username').'', 'required|min_length['.$usernameMinLength.']|max_length[128]|user_username_unique[username]|xss_clean');
         $this->form_validation->set_rules('email', 'E-mail', 'required|min_length[5]|max_length[128]|valid_email|user_mail_unique[email]|xss_clean');
         $this->form_validation->set_rules('password', 'Password', 'required|min_length[5]|max_length[23]|matches[passwordconf]');
         $this->form_validation->set_rules('passwordconf', 'Password Confirmation', 'required|min_length[5]|max_length[23]');


### PR DESCRIPTION
The minimum username length should not be hard-coded. In my use case there are some rare usernames with length of 3 characters. So I'm suggesting making the required minimal length configurable. Maybe some other parameters could be configurable too.
