### PR TITLE
enable to decide what digest method should be used to sign metadata

### DIFF
--- a/application/controllers/Msigner.php
+++ b/application/controllers/Msigner.php
@@ -35,6 +35,12 @@ class Msigner extends MY_Controller {
        }
 
 
+       $digestmethod = $this->config->item('signdigest');
+       if(empty($digestmethod))
+       {
+          $digestmethod = 'SHA-1';
+       }
+
        $type =  $this->uri->segment(3);
        $id = $this->uri->segment(4);
        if(empty($type) || empty($id))
@@ -100,13 +106,24 @@ class Msigner extends MY_Controller {
                return;
            }
            //$encfedname = base64url_encode($fed->getName());
+           $digest1 = $fed->getDigest();
+           if(empty($digest1))
+           {
+              $digest1 = $digestmethod;
+           }
+           $digest2 = $fed->getDigestExport();
+           if(empty($digest2))
+           {
+              $digest2 = $digestmethod;
+           }
+            
            $encfedname = $fed->getSysname();
            $sourceurl = base_url().'metadata/federation/'.$encfedname.'/metadata.xml';
-           $options[] = array('src'=>''.$sourceurl.'','type'=>'federation','encname'=>''.$encfedname.'');
+           $options[] = array('src'=>''.$sourceurl.'','type'=>'federation','encname'=>''.$encfedname.'','digest'=>''.$digest1.'');
            $localexport = $fed->getLocalExport();
            if(!empty($localexport))
            {
-              $options[] = array('src'=>''.base_url().'metadata/federationexport/'.$encfedname.'/metadata.xml','type'=>'federationexport','encname'=>''.$encfedname.'');
+              $options[] = array('src'=>''.base_url().'metadata/federationexport/'.$encfedname.'/metadata.xml','type'=>'federationexport','encname'=>''.$encfedname.'','digest'=>''.$digest2.'');
            }
 
            foreach($options as $opt)
@@ -140,10 +157,15 @@ class Msigner extends MY_Controller {
               echo lang('error403');
               return;
           }
+          $digest1 = $provider->getDigest();
+          if(empty($digest1))
+          {
+             $digest1 = $digestmethod;
+          }
           $options = array();
           $encodedentity = base64url_encode($provider->getEntityId()); 
           $sourceurl = base_url().'metadata/circle/'.$encodedentity.'/metadata.xml';
-          $options[] = array('src'=>''.$sourceurl.'','type'=>'provider','encname'=>''.$encodedentity.'');
+          $options[] = array('src'=>''.$sourceurl.'','type'=>'provider','encname'=>''.$encodedentity.'','digest'=>''.$digest1.'');
           foreach($options as $opt)
           {
               try{

--- a/application/controllers/federations/Manage.php
+++ b/application/controllers/federations/Manage.php
@@ -343,6 +343,23 @@ class Manage extends MY_Controller
         if (!empty($b) and is_array($b) and isset($b['fed'][$data['federation_id']])) {
             $bookmarked = true;
         }
+        $defaultDigest = $this->config->item('signdigest');
+        if(empty($defaultDigest))
+        {
+          $defaultDigest = 'SHA-1';
+        }
+
+        $digest = $federation->getDigest();
+        if(empty($digest))
+        {
+          $digest = $defaultDigest;
+        }
+        $digestExport = $federation->getDigestExport();
+        if(empty($digestExport))
+        {
+           $digestExport = $defaultDigest;
+        }
+        
         $data['bookmarked'] = $bookmarked;
         $data['federation_name'] = $federation->getName();
         $data['federation_sysname'] = $federation->getSysname();
@@ -479,17 +496,17 @@ class Manage extends MY_Controller
             $BOTHmembersInArrayToHtml = $this->show_element->MembersToHtml($membersInArray['both']);
             $data['result']['metadata'][] = array(lang('rr_fedmetaunsingedlink'), $data['meta_link'] . " " . anchor($data['meta_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"'));
 
-            $data['result']['metadata'][] = array(lang('rr_fedmetasingedlink'), $data['meta_link_signed'] . " " . anchor_popup($data['meta_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
+            $data['result']['metadata'][] = array(lang('rr_fedmetasingedlink').' <span class="label">'.$digest.'</span>', $data['meta_link_signed'] . " " . anchor_popup($data['meta_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
 
             $lexportenabled = $federation->getLocalExport();
             if ($lexportenabled === TRUE) {
                 $data['result']['metadata'][] = array(lang('rr_fedmetaexportunsingedlink'), $data['metaexport_link'] . " " . anchor_popup($data['metaexport_link'], '<img src="' . base_url() . 'images/icons/arrow.png"/>','class="showmetadata"'));
-                $data['result']['metadata'][] = array(lang('rr_fedmetaexportsingedlink'), $data['metaexport_link_signed'] . " " . anchor_popup($data['metaexport_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
+                $data['result']['metadata'][] = array(lang('rr_fedmetaexportsingedlink').' <span class="label">'.$digestExport.'</span>', $data['metaexport_link_signed'] . " " . anchor_popup($data['metaexport_link_signed'], '<img src="' . base_url() . 'images/icons/arrow.png"/>'));
             }
 
             $gearmanenabled = $this->config->item('gearman');
             if ($has_write_access && !empty($gearmanenabled)) {
-                $data['result']['metadata'][] = array('' . lang('signmetadata') . showBubbleHelp(lang('rhelp_signmetadata')) . '', '<a href="' . base_url() . 'msigner/signer/federation/' . $federation->getId() . '" id="fedmetasigner"/><button type="button" class="savebutton staricon">' . lang('btn_signmetadata') . '</button></a>', '');
+                $data['result']['metadata'][] = array('' . lang('signmetadata') . showBubbleHelp(lang('rhelp_signmetadata')) . '', '<a href="' . base_url() . 'msigner/signer/federation/' . $federation->getId() . '" id="fedmetasigner"/><button type="button" class="savebutton staricon tiny">' . lang('btn_signmetadata') . '</button></a>', '');
             }
 
             $data['result']['membership'][] = array('data' => array('data' => lang('identityprovidersmembers'), 'class' => 'highlight', 'colspan' => 2));

--- a/application/controllers/manage/Fededit.php
+++ b/application/controllers/manage/Fededit.php
@@ -45,6 +45,7 @@ class Fededit extends MY_Controller {
         {
            $fedid = $this->fedid;
         }
+        $allowedDigests = array('SHA-1','SHA-256');
         $ar1 = array('attr'=>'name','fedid'=>''.$fedid.'');
         $this->form_validation->set_rules('fedname', lang('rr_fed_name'), 'trim|required|min_length[5]|max_length[128]|xss_clean|federation_updateunique['.serialize($ar1).']');
         $ar2 = array('attr'=>'urn','fedid'=>''.$fedid.'');
@@ -55,6 +56,9 @@ class Fededit extends MY_Controller {
         $this->form_validation->set_rules('ispublic',lang('rr_isfedpublic'),'trim|xss_clean|max_length[10]');
         $this->form_validation->set_rules('lexport',lang('rr_lexport_enabled'),'trim|xss_clean|max_length[10]');
         $this->form_validation->set_rules('publisher',lang('rr_fed_publisher'),'trim|xss_clean|max_length[500]');
+        $this->form_validation->set_rules('digestmethod',lang('digestmethodsign'),'trim|xss_clean|matches_inarray['.serialize($allowedDigests).']');
+        $this->form_validation->set_rules('digestmethodext',lang('digestmethodexportsign'),'trim|xss_clean|matches_inarray['.serialize($allowedDigests).']');
+
         return $this->form_validation->run();
     }
 
@@ -70,6 +74,7 @@ class Fededit extends MY_Controller {
         {
             show_error(lang('error_fednotfound'), 404);
         }
+        $allowedDigests = array('SHA-1','SHA-256');
         $this->load->library('form_element');
         $resource = $fed->getId();
         $this->fedid = $resource;
@@ -93,6 +98,8 @@ class Fededit extends MY_Controller {
             $lexport = $this->input->post('lexport');
             $ispublic = $this->input->post('ispublic');
             $publisher = $this->input->post('publisher');
+            $digest = $this->input->post('digestmethod');
+            $digestExport = $this->input->post('digestmethodext');
             if ($infedid != $fedid)
             {
                 show_error('Incorrect post', 403);
@@ -127,6 +134,8 @@ class Fededit extends MY_Controller {
             $fed->setPublisher($publisher);
             $fed->setDescription($indesc);
             $fed->setTou($intou);
+            $fed->setDigest($digest);
+            $fed->setDigestExport($digestExport);
             $this->em->persist($fed);
             try
             {

--- a/application/language/english/rr_lang.php
+++ b/application/language/english/rr_lang.php
@@ -87,7 +87,8 @@ $lang['btnparsemeta']               = 'Parse metadata';
 $lang['btnaddinlang']               = 'Add in new language';
 $lang['regpol_language'] =            'Language';
 $lang['rr_lang'] =                  'Language';
-
+$lang['digestmethodsign']          = 'Digest method for signing metadata';
+$lang['digestmethodexportsign']          = 'Digest method for signing exported metadata';
 $lang['rr_administration'] =        'Administration';
 $lang['advancedmode']              = 'Advanced mode';
 $lang['btnlogout']                 = 'Sign out';

--- a/application/libraries/Form_element.php
+++ b/application/libraries/Form_element.php
@@ -2377,6 +2377,64 @@ class Form_element {
         return $result;
     }
 
+    public function NgenerateLogoForm(models\Provider $ent, $ses = null)
+    {
+       $langs = languagesCodes();
+       $type = $ent->getType();
+       $sessform = FALSE;
+       if(is_array($ses))
+       {
+          $sessform = TRUE;
+       }
+       
+       if(!$sessform)
+       {
+          $metaext = $ent->getExtendMetadata();
+          foreach($metaext as $v)
+          {
+             $velement = $v->getElement();
+             if(strcmp($velement,'Logo')!=0)
+             {
+                continue;
+             }
+             $attrs = $v->getAttributes();
+             if(isset($attrs['xml:lang']))
+             {
+               $lang = $attrs['lang'];
+             }
+             else
+             {
+               $lang = 0;
+             }
+             $logos[$v->getType()][''.$v->getId().''] = array(
+                'url'=>''.$v->getLogoValue().'',
+                'lang'=> ''.$lang.'',
+                'width'=>$attrs['width'],
+                'height'=>$attrs['height'],
+             );
+             
+
+          }
+       }
+       $result = array();
+
+       $result[] = '';
+       $p='<ul class="clearing-thumbs small-block-grid-4" data-clearing>';
+       foreach($logos['idp'] as $k=>$v)
+       {
+          //$result[] = '<img src="'.$v['url'].'"/>';
+          $p .= '<li><a href="'.$v['url'].'"><img data-caption="caption here..." src="'.$v['url'].'"></a></li>';
+       }
+       $p .= '</ul>';
+       $result[] =$p;
+       $result[] = '';
+
+     
+       return $result;
+       
+      
+    }
+
     public function NgenerateUiiForm(models\Provider $ent, $ses = null)
     {
 
@@ -2427,11 +2485,11 @@ class Form_element {
             /**
              * start display
              */
-            $result[] = '';
             if (strcasecmp($type, 'BOTH') == 0)
             {
                 $result[] = '<div class="section">' . lang('identityprovider') . '</div>';
             }
+            $result[] = '';
             //$result[] = '<div class="langgroup">' . lang('e_idpservicename') . '</div>';
             $r = '';
             $langsdisplaynames = $langs;
@@ -2713,11 +2771,11 @@ class Form_element {
             /**
              * start display
              */
-            $result[] = '';
             if (strcasecmp($type, 'BOTH') == 0)
             {
-                $result[] = '<div class="section label small-12">' . lang('serviceprovider') . '</div>';
+                $result[] = '<div class="section">' . lang('serviceprovider') . '</div>';
             }
+            $result[] = '';
             //$result[] = '<div class="langgroup">' . lang('e_spservicename') . '</div>';
             $r = '';
             $langsdisplaynames = $langs;
@@ -3167,9 +3225,19 @@ class Form_element {
         $f .= '<div class="small-12 columns">';
         $f .= '<div class="small-3 columns">' . form_label(lang('rr_include_attr_in_meta'), 'incattrs') . '</div><div class="small-8 large-7 columns">' . form_checkbox('incattrs', 'accept', set_value('incattrs', $federation->getAttrsInmeta())) . '</div><div class="small-1 large-2 "></div></div>';
         $f .= '</div>';
+
         $f .= '<div class="small-12 columns">';
         $f .= '<div class="small-3 columns">' . form_label(lang('rr_lexport_enabled'), 'lexport') . '</div><div class="small-8 large-7 columns">' . form_checkbox('lexport', 'accept', set_value('lexport', $federation->getLocalExport())) . '</div><div class="small-1 large-2 "></div>';
         $f .= '</div>';
+
+        $f .= '<div class="small-12 columns">';
+        $f .= '<div class="small-3 columns">' . form_label(lang('digestmethodsign'), 'digestmethod') . '</div><div class="small-8 large-7 columns">' . form_dropdown('digestmethod', array('SHA-1'=>'SHA-1','SHA-256'=>'SHA-256'), set_value('digestmethod', $federation->getDigest())) . '</div><div class="small-1 large-2 "></div>';
+        $f .= '</div>';
+
+        $f .= '<div class="small-12 columns">';
+        $f .= '<div class="small-3 columns">' . form_label(lang('digestmethodexportsign'), 'digestmethodext') . '</div><div class="small-8 large-7 columns">' . form_dropdown('digestmethodext', array('SHA-1'=>'SHA-1','SHA-256'=>'SHA-256'), set_value('digestmethodext', $federation->getDigestExport())) . '</div><div class="small-1 large-2 "></div>';
+        $f .= '</div>';
+
         $f .= '<div class="small-12 columns">';
         $f .='<div class="small-3 columns">' . form_label(lang('rr_description'), 'description') . '</div>';
         $f .='<div class="small-8 large-7 columns">' . form_textarea('description', set_value('description', $federation->getDescription())) . '</div>';

--- a/application/models/Federation.php
+++ b/application/models/Federation.php
@@ -98,6 +98,18 @@ class Federation
      */
     protected $is_local;
 
+
+    /**
+     * @Column(name="digest", type="string",length=10, nullable=true)
+     */
+     protected $digest;
+
+    /**
+     * @Column(name="digestexport", type="string",length=10, nullable=true)
+     */
+     protected $digestexport;
+
+
      /**
       * add attribute requirements into generated metadata
       * @Column(name="attrreq_inmeta", type="boolean", nullable=false)
@@ -180,6 +192,18 @@ class Federation
        return $this;
    }
     
+
+   public function setDigest($a=null)
+   {
+      $this->digest = $a;
+      return $this;
+   }
+   public function setDigestExport($a=null)
+   {
+      $this->digestexport = $a;
+      return $this;
+   }
+
 
     public function setUrn($urn)
     {
@@ -514,6 +538,15 @@ class Federation
     public function getTou()
     {
         return $this->tou;
+    }
+
+    public function getDigest()
+    {
+        return $this->digest;
+    }
+    public function getDigestExport()
+    {
+        return $this->digestexport;
     }
 
     public function getOwner()

--- a/application/models/Provider.php
+++ b/application/models/Provider.php
@@ -111,6 +111,11 @@ class Provider {
      */
     protected $scope;
 
+    /**
+     * @Column(type="string",length=10, nullable=true)
+     */
+    protected $digest;
+
 
     /**
      * helpdeskurl is used in metadata, it can be http(s) or mailto
@@ -841,6 +846,12 @@ class Provider {
         {
             return false;
         }
+    }
+
+    public function setDigest($a=null)
+    {
+       $this->digest = $a;
+       return $this;
     }
 
     public function setCountry($country = null)
@@ -2066,6 +2077,11 @@ class Provider {
         return $this->_em->createQuery('SELECT u FROM Models\Provider u WHERE name = "' . $name . '"')->getResult();
     }
 
+    public function getDigest()
+    {
+       return $this->digest;
+    }
+
     public function getValidTo()
     {
         return $this->validto;
@@ -2075,6 +2091,8 @@ class Provider {
     {
         return $this->validfrom;
     }
+
+   
 
     /**
      * return boolean if entity is between validfrom and validto dates


### PR DESCRIPTION
related circle, federation, federation export metadata;
added two columns (digest, digestexport) into federation and one column (digest) into provider entity model;
you can define default digest in config_rr.php
$config['signdigest'] = 'SHA-1'  or $config['signdigest'] = 'SHA-256'
if not found then default is set to  SHA-1
You can override default setting for federation (standard and export metadat)
ths information is passed by gearman client to gearman job server - see example gearman worker on  https://github.com/janul/rr3-addons/blob/master/gearman-workers/gearman-worker-metasigner.py
Also digest is passed to the list  https://SRV/jagger/sync_metadata/metadataslist  if you use cron scripts
Obviously it's stil up to metadata signer tool what digest is used but based on provided information yo can customize your tool more easily givin mor controlr to federation/providers operators

after update you need to rerun doctrine-cli to update db and regenerate model/proxies
