### PR TITLE
Colour validator button depending on results

### DIFF
--- a/application/libraries/J_queue.php
+++ b/application/libraries/J_queue.php
@@ -622,12 +622,12 @@ class J_queue
                 if($v->getMandatory()) {
                     $hidden = array('fedid' => $federation->getId(), 'provid' => $provider->getId(), 'fvid' => $v->getId());
                     $valMandatory .= form_open(base_url().'federations/fvalidator/validate', $attrs, $hidden);
-                    $valMandatory .= '<button title="'.$v->getDescription().'">'.$v->getName().'</button> ';
+                    $valMandatory .= '<button id="'.$v->getId().'" title="'.$v->getDescription().'">'.$v->getName().'</button> ';
                     $valMandatory .= form_close();
                 } else {
                     $hidden = array('fedid' => $federation->getId(), 'provid' => $provider->getId(), 'fvid' => $v->getId());
                     $valOptional .= form_open(base_url().'federations/fvalidator/validate', $attrs, $hidden);
-                    $valOptional .= '<button title="'.$v->getDescription().'">'.$v->getName().'</button> ';
+                    $valOptional .= '<button id="'.$v->getId().'" title="'.$v->getDescription().'">'.$v->getName().'</button> ';
                     $valOptional .= form_close();
                 }
             }

--- a/js/locals-v5.js
+++ b/js/locals-v5.js
@@ -656,6 +656,7 @@ var GINIT = {
             e.preventDefault();
             var str = $(this).serializeArray();
             var url = $("form#fvform").attr('action');
+            var fvid = $(this).find("button:focus").attr('id');
 
             $.ajax({
                 type: "POST",
@@ -676,6 +677,16 @@ var GINIT = {
                         {
                             $("span#fvreturncode").append(data.returncode);
                             $("div#fvresult").show();
+                        }
+                        if (data.returncode == "success")
+                        {
+                            document.getElementById(fvid).style.backgroundColor = "#00aa00";
+                            document.getElementById(fvid).style.borderColor     = "#00aa00";
+                            document.getElementById(fvid).disabled              = true;
+                        } else if (data.returncode == "error")
+                        {
+                            document.getElementById(fvid).style.backgroundColor = "#aa0000";
+                            document.getElementById(fvid).style.borderColor     = "#aa0000";
                         }
                         if (data.message)
                         {


### PR DESCRIPTION
Before a join federation request is accepted or rejected, it's possible
to validate it first. When a validator fails the button is coloured red.
When a validator passes the button is coloured green. Just eye-candy,
but might help when more validators are used in a federation.

P.S. It's just a quick hack, maybe you'll find a better way to implement
it in JS. Don't know jQuery too well.
