### PR TITLE
User registration fix

### DIFF
--- a/application/controllers/reports/Awaiting.php
+++ b/application/controllers/reports/Awaiting.php
@@ -189,7 +189,7 @@ class Awaiting extends MY_Controller
                     'requester' => $c_creator,
                     'idate' => $q->getCreatedAt(),
                     'datei' => $q->getCreatedAt(),
-                    'iname' => $q->getName(),
+                    'iname' => $q->getCN(),
                     'qid' => $q->getId(),
                     'mail' => $q->getEmail(),
                     'type' => $q->getType(),

--- a/application/models/Queue.php
+++ b/application/models/Queue.php
@@ -265,6 +265,12 @@ class Queue {
         return unserialize($this->objdata);
     }
 
+    public function getCN() {
+        $data = unserialize($this->objdata);
+        $cn = $data['fname'] . " " . $data['sname'];
+        return $cn;
+    }
+
     public function getName() {
         return $this->name;
     }


### PR DESCRIPTION
When a user asks for a registration, eppn is shown in the table 'Awating
list for approval' in the Queue instead of his/hers name. This is a fix.
