### PR TITLE
Fix checks for keys to generate cn

### DIFF
--- a/application/models/Queue.php
+++ b/application/models/Queue.php
@@ -270,11 +270,11 @@ class Queue {
         $cn = '';
         if(array_key_exists('fname',$data))
         {
-           $cn .= $data['fname'];
+           $cn .= $data['fname'] . " ";
         }
         if(array_key_exists('sname',$data))
         {
-           $cn = $data['fname'] . " " . $data['sname'];
+           $cn .= $data['sname'];
         }
         return $cn;
     }


### PR DESCRIPTION
I guess that the second `if` was incorrect, because it didn't check
`fname` availability, it just used it. Now, if `fname` is available,
it's used and `sname` is added when available.
