### PR TITLE
Show requester's full name and username in requests

### DIFF
--- a/application/controllers/reports/Awaiting.php
+++ b/application/controllers/reports/Awaiting.php
@@ -170,6 +170,7 @@ class Awaiting extends MY_Controller
             if (!empty($creator))
             {
                 $c_creator = $creator->getUsername();
+                $c_creatorCN = $creator->getFullname();
             }
             $recipientid = $q->getRecipient();
             $recipenttype = $q->getRecipientType();
@@ -187,6 +188,7 @@ class Awaiting extends MY_Controller
                 $result['q'][$kid++] = array(
                     'issubscription'=>0,
                     'requester' => $c_creator,
+                    'requesterCN' => $c_creatorCN,
                     'idate' => $q->getCreatedAt(),
                     'datei' => $q->getCreatedAt(),
                     'iname' => $q->getCN(),

--- a/application/controllers/reports/Awaiting.php
+++ b/application/controllers/reports/Awaiting.php
@@ -161,6 +161,7 @@ class Awaiting extends MY_Controller
         foreach ($queueArray as $q)
         {
             $c_creator = 'anonymous';
+            $c_creatorCN = 'Anonymous';
             $creator = $q->getCreator();
             $access = $this->hasQAccess($q);
             if (!$access)

--- a/application/libraries/J_queue.php
+++ b/application/libraries/J_queue.php
@@ -334,7 +334,7 @@ class J_queue
         $creator = $q->getCreator();
         if ($creator)
         {
-            $fedrows[] = array('name' => lang('requestor'), 'value' => $creator->getUsername());
+            $fedrows[] = array('name' => lang('requestor'), 'value' => $creator->getFullname() .' ('. $creator->getUsername() .')');
         }
         else
         {
@@ -434,6 +434,10 @@ class J_queue
         $i = 0;
         $feds = $objData->getFederations();
         $fedIdsCollection = array();
+
+        $dataRows[$i++]['header'] = lang('rr_details');
+        $dataRows[$i]['name'] = lang('requestor');
+        $dataRows[$i++]['value'] = $q->getCreator()->getFullname() ." (". $q->getCreator()->getUsername() .")";
 
         $dataRows[$i++]['header'] = lang('rr_fedstojoin');
         if ($feds->count() > 0)
@@ -668,7 +672,7 @@ class J_queue
         $this->ci->table->add_row($cell);
         $cell = array('data' => lang('rr_details'), 'class' => 'highlight', 'colspan' => 2);
         $this->ci->table->add_row($cell);
-        $cell = array(lang('requestor'), $queue->getCreator()->getUsername() . ' (' . $queue->getCreator()->getFullname() . ') : email: ' . $queue->getCreator()->getEmail());
+        $cell = array(lang('requestor'), $queue->getCreator()->getFullname() . ' (' . $queue->getCreator()->getUsername() . ')');
         $this->ci->table->add_row($cell);
         $validators = $federation->getValidators();
         $fedValidator = null;

--- a/application/views/reports/awaiting_list_view.php
+++ b/application/views/reports/awaiting_list_view.php
@@ -30,7 +30,7 @@ if (!empty($list))
         }
         $cdate = $q['idate'];
         $detail = anchor(base_url() . "/reports/awaiting/detail/" . $q['token'], '<i class="fi-arrow-right"></i>');
-        $this->table->add_row($q['idate'], $q['requesterCN'] ."(". $q['requester'] .")", $q['type'] . " - " . $q['action'], $q['mail'], $q['iname'], $confirm, $detail);
+        $this->table->add_row($q['idate'], $q['requesterCN'] ." (". $q['requester'] .")", $q['type'] . " - " . $q['action'], $q['mail'], $q['iname'], $confirm, $detail);
     }
     echo $this->table->generate();
     $this->table->clear();

--- a/application/views/reports/awaiting_list_view.php
+++ b/application/views/reports/awaiting_list_view.php
@@ -30,7 +30,7 @@ if (!empty($list))
         }
         $cdate = $q['idate'];
         $detail = anchor(base_url() . "/reports/awaiting/detail/" . $q['token'], '<i class="fi-arrow-right"></i>');
-        $this->table->add_row($q['idate'], $q['requester'], $q['type'] . " - " . $q['action'], $q['mail'], $q['iname'], $confirm, $detail);
+        $this->table->add_row($q['idate'], $q['requesterCN'] ."(". $q['requester'] .")", $q['type'] . " - " . $q['action'], $q['mail'], $q['iname'], $confirm, $detail);
     }
     echo $this->table->generate();
     $this->table->clear();

--- a/application/views/reports/dashawaiting_list_view.php
+++ b/application/views/reports/dashawaiting_list_view.php
@@ -28,7 +28,7 @@ if (!empty($list))
         }
         $cdate = $q['idate'];
         $detail = anchor(base_url()."/reports/awaiting/detail/" . $q['token'], '<i class="fi-arrow-right"></i>');
-        $this->table->add_row($q['idate'], $q['requester'], $q['recipientname'].'<br />'.$q['type'] . " - " . $q['action'], $detail);
+        $this->table->add_row($q['idate'], $q['requesterCN'] ." (". $q['requester'] .")", $q['recipientname'].'<br />'.$q['type'] . " - " . $q['action'], $detail);
     }
     echo $this->table->generate();
     $this->table->clear();


### PR DESCRIPTION
Usernames are sometimes pointless strings (i.e. 035965@example.org). Full names are better, however, some are quite common such as James Smith. Thus using full name in combination with username/eppn is probably the best solution to identify the requester.
