### PR TITLE
single AttributeAuthorityDescriptor role support

### DIFF
--- a/application/controllers/manage/Entityedit.php
+++ b/application/controllers/manage/Entityedit.php
@@ -254,7 +254,7 @@ class Entityedit extends MY_Controller
 
             if (array_key_exists('lname', $y['f'])) {
                 foreach ($y['f']['lname'] as $k => $v) {
-                    $this->form_validation->set_rules('f[lname][' . $k . ']', ucfirst(lang('localizednamein')) . ' ' . $k, 'strip_tags|trim');
+                    $this->form_validation->set_rules('f[lname][' . $k . ']', ucfirst(lang('e_orgname')) . ' ' . $k, 'strip_tags|trim');
                 }
                 if (count(array_filter($y['f']['lname'])) == 0) {
                     $this->tmp_error = lang('errnoorgnames');
@@ -266,7 +266,7 @@ class Entityedit extends MY_Controller
             }
             if (array_key_exists('ldisplayname', $y['f'])) {
                 foreach ($y['f']['ldisplayname'] as $k => $v) {
-                    $this->form_validation->set_rules('f[ldisplayname][' . $k . ']', ucfirst(lang('localizeddisplaynamein')) . ' ' . $k, 'strip_tags|trim');
+                    $this->form_validation->set_rules('f[ldisplayname][' . $k . ']', ucfirst(lang('e_orgdisplayname')) . ' ' . $k, 'strip_tags|trim');
                 }
                 if (count(array_filter($y['f']['ldisplayname'])) == 0) {
                     $this->tmp_error = lang('errnoorgdisnames');
@@ -282,7 +282,7 @@ class Entityedit extends MY_Controller
                     /**
                      * @todo GEO validation
                      */
-                    $this->form_validation->set_rules('f[uii][idpsso][geo][' . $k . ']', 'Geolocation ', 'strip_tags|trim|min_length[3]|max_length[40]|valid_latlng');
+                    $this->form_validation->set_rules('f[uii][idpsso][geo][' . $k . ']', lang('rr_geo').' ', 'strip_tags|trim|min_length[3]|max_length[40]|valid_latlng');
                 }
             }
 
@@ -315,18 +315,24 @@ class Entityedit extends MY_Controller
 
             if (array_key_exists('lhelpdesk', $y['f'])) {
                 foreach ($y['f']['lhelpdesk'] as $k => $v) {
-                    $this->form_validation->set_rules('f[lhelpdesk][' . $k . ']', lang('localizedhelpdeskin') . ' ' . $k, 'strip_tags|trim|required|valid_url');
+                    $this->form_validation->set_rules('f[lhelpdesk][' . $k . ']', lang('e_orgurl') . ' ', 'strip_tags|trim|valid_url');
                 }
-
+                $y['f']['lhelpdesk'] = array_filter($y['f']['lhelpdesk']);
+                if(count($y['f']['lhelpdesk']) == 0)
+                {
+                    $this->tmp_error = lang('errnoorgurls');
+                    $optValidationsPassed = FALSE;
+                }
             } else {
                 $this->tmp_error = lang('errnoorgurls');
                 $optValidationsPassed = FALSE;
             }
 
 
+
             if (array_key_exists('contact', $y['f'])) {
                 foreach ($y['f']['contact'] as $k => $v) {
-                    $this->form_validation->set_rules('f[contact][' . $k . '][email]', '' . lang('rr_contactemail') . '', 'trim|htmlspecialchars|valid_email');
+                    $this->form_validation->set_rules('f[contact][' . $k . '][email]', '' . lang('rr_contactemail') . '', 'trim|valid_email');
                     $this->form_validation->set_rules('f[contact][' . $k . '][type]', '' . lang('rr_contacttype') . '', 'trim|htmlspecialchars|valid_contact_type');
                     $this->form_validation->set_rules('f[contact][' . $k . '][fname]', '' . lang('rr_contactfirstname') . '', 'trim|htmlspecialchars');
                     $this->form_validation->set_rules('f[contact][' . $k . '][sname]', '' . lang('rr_contactlastname') . '', 'trim|htmlspecialchars');
@@ -348,21 +354,22 @@ class Entityedit extends MY_Controller
                 if (array_key_exists('spsso', $y['f']['crt'])) {
                     foreach ($y['f']['crt']['spsso'] as $k => $v) {
                         if (is_numeric($k)) {
-                            $this->form_validation->set_rules('f[crt][spsso][' . $k . '][certdata]', 'cert data', 'trim|getPEM|verify_cert_nokeysize');
+                            $this->form_validation->set_rules('f[crt][spsso][' . $k . '][certdata]', 'SPSSODescriptor/Certificate body', 'trim|required|getPEM|verify_cert_nokeysize');
                         } else {
-                            $this->form_validation->set_rules('f[crt][spsso][' . $k . '][certdata]', 'cert data', 'trim|getPEM|verify_cert');
+                            $this->form_validation->set_rules('f[crt][spsso][' . $k . '][certdata]', 'SPSSoDescriptor/Certificate body', 'trim|required|getPEM|verify_cert');
                         }
                         $this->form_validation->set_rules('f[crt][spsso][' . $k . '][usage]', '' . lang('rr_certificateuse') . '', 'htmlspecialchars|trim|required');
                         $this->form_validation->set_rules('f[crt][spsso][' . $k . '][encmethods][]', 'Certificate EncryptionMethod', 'trim|in_list[' . $allowedEnryptionMethodsInList . ']');
+
 
                     }
                 }
                 if (array_key_exists('idpsso', $y['f']['crt'])) {
                     foreach ($y['f']['crt']['idpsso'] as $k => $v) {
                         if (is_numeric($k)) {
-                            $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][certdata]', 'Certificate', 'trim|getPEM|verify_cert_nokeysize');
+                            $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][certdata]', 'IDPSSODescriptor/Certificate body', 'trim|required|getPEM|verify_cert_nokeysize');
                         } else {
-                            $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][certdata]', 'Certificate', 'trim|getPEM|verify_cert');
+                            $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][certdata]', 'IDPSSODescriptor/Certificate body', 'trim|required|getPEM|verify_cert');
                         }
                         $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][usage]', '' . lang('rr_certificateuse') . '', 'htmlspecialchars|trim|required');
                         $this->form_validation->set_rules('f[crt][idpsso][' . $k . '][encmethods][]', 'Certificate EncryptionMethod', 'trim|in_list[' . $allowedEnryptionMethodsInList . ']');
@@ -371,9 +378,9 @@ class Entityedit extends MY_Controller
                 if (array_key_exists('aa', $y['f']['crt'])) {
                     foreach ($y['f']['crt']['aa'] as $k => $v) {
                         if (is_numeric($k)) {
-                            $this->form_validation->set_rules('f[crt][aa][' . $k . '][certdata]', 'Certificate', 'trim|getPEM|verify_cert_nokeysize');
+                            $this->form_validation->set_rules('f[crt][aa][' . $k . '][certdata]', 'AttributeAuthorityDescriptor/Certificate body', 'trim|required|getPEM|verify_cert_nokeysize');
                         } else {
-                            $this->form_validation->set_rules('f[crt][aa][' . $k . '][certdata]', 'Certificate', 'trim|getPEM|verify_cert');
+                            $this->form_validation->set_rules('f[crt][aa][' . $k . '][certdata]', 'AttributeAuthorityDescriptor/Certificate body', 'trim|required|getPEM|verify_cert');
                         }
                         $this->form_validation->set_rules('f[crt][aa][' . $k . '][usage]', '' . lang('rr_certificateuse') . '', 'htmlspecialchars|trim|required');
                         $this->form_validation->set_rules('f[crt][aa][' . $k . '][encmethods][]', 'Certificate EncryptionMethod', 'trim|in_list[' . $allowedEnryptionMethodsInList . ']');
@@ -384,14 +391,21 @@ class Entityedit extends MY_Controller
             /**
              * service locations
              */
-            $nosso = 0;
+            $idpssoSrvsLocations = 0;
+
+            $aaSrvsLocations = 0;
             $nossobindings = array();
             $noidpslo = array();
             if (array_key_exists('srv', $y['f'])) {
                 if (array_key_exists('IDPAttributeService', $y['f']['srv'])) {
                     foreach ($y['f']['srv']['IDPAttributeService'] as $k => $v) {
-                        $this->form_validation->set_rules('f[srv][IDPAttributeService][' . $k . '][url]', 'AttributeAuthorityDescriptor/AttributeService: ' . html_escape($y['f']['srv']['SingleSignOnService']['' . $k . '']['bind']), 'strip_tags|trim|max_length[254]|valid_url');
+                        $this->form_validation->set_rules('f[srv][IDPAttributeService][' . $k . '][url]', 'AttributeAuthorityDescriptor/AttributeService: ' . html_escape($y['f']['srv']['IDPAttributeService']['' . $k . '']['bind']), 'strip_tags|trim|max_length[254]|valid_url');
+                        if(!empty($y['f']['srv']['IDPAttributeService'][''.$k.'']['url']))
+                        {
+                           ++$aaSrvsLocations;
+                        }
                     }
+
                 }
                 if (!array_key_exists('SingleSignOnService', $y['f']['srv'])) {
                     $y['f']['srv']['SingleSignOnService'] = array();
@@ -401,7 +415,7 @@ class Entityedit extends MY_Controller
                     $tmp1 = $this->form_validation->set_rules('f[srv][SingleSignOnService][' . $k . '][url]', 'SingleSignOnService URL for: ' . $y['f']['srv']['SingleSignOnService']['' . $k . '']['bind'], 'strip_tags|trim|max_length[254]|valid_url');
                     $tmp2 = $this->form_validation->set_rules('f[srv][SingleSignOnService][' . $k . '][bind]', 'SingleSignOnService Binding protocol', 'htmlspecialchars|required');
                     if ($tmp1 && $tmp2 && !empty($y['f']['srv']['SingleSignOnService']['' . $k . '']['url'])) {
-                        ++$nosso;
+                        ++$idpssoSrvsLocations;
                     }
                 }
                 if (array_key_exists('IDPSingleLogoutService', $y['f']['srv'])) {
@@ -429,7 +443,7 @@ class Entityedit extends MY_Controller
                     foreach ($y['f']['srv']['AssertionConsumerService'] as $k => $v) {
                         $this->form_validation->set_rules('f[srv][AssertionConsumerService][' . $k . '][url]', 'AssertionConsumerService URL', 'strip_tags|trim|max_length[254]|valid_url');
                         $this->form_validation->set_rules('f[srv][AssertionConsumerService][' . $k . '][bind]', 'AssertionConsumerService Binding protocol', 'trim|htmlspecialchars');
-                        $this->form_validation->set_rules('f[srv][AssertionConsumerService][' . $k . '][order]', 'AssertionConsumerService Index', 'trim|htmlspecialchars');
+                        $this->form_validation->set_rules('f[srv][AssertionConsumerService][' . $k . '][order]', 'AssertionConsumerService index', 'trim|htmlspecialchars');
 
                         $tmpurl = trim($y['f']['srv']['AssertionConsumerService']['' . $k . '']['url']);
                         $tmporder = trim($y['f']['srv']['AssertionConsumerService']['' . $k . '']['order']);
@@ -556,8 +570,8 @@ class Entityedit extends MY_Controller
             $result = $this->form_validation->run();
             if (strcasecmp($this->type, 'SP') != 0) {
 
-                if (empty($nosso) && !$staticisdefault) {
-                    $this->tmp_error = 'At least one SSO must be set';
+                if (empty($idpssoSrvsLocations) && empty($aaSrvsLocations) && !$staticisdefault) {
+                    $this->tmp_error = lang('errmissssoaasrvs');
                     return false;
                 }
                 if (!empty($nossobindings) && is_array($nossobindings) && count($nossobindings) > 0 && count(array_unique($nossobindings)) < count($nossobindings)) {

--- a/application/controllers/manage/Users.php
+++ b/application/controllers/manage/Users.php
@@ -813,6 +813,24 @@ class Users extends MY_Controller
             $this->load->view('page', $data);
             return;
         }
+        $accessListUsers = $this->zacl->check_acl('', 'read', 'user', '');
+        if (!$accessListUsers)
+        {
+            $breadcrumbs = array(
+                array('url' => base_url('manage/users/showlist'), 'name' => lang('rr_userslist'), 'type' => 'unavailable'),
+                array('url' => base_url('manage/users/show/'.$encoded_username.''), 'name' => html_escape($user->getUsername())),
+                array('url' => base_url('#'), 'name' => lang('rr_changepass'), 'type' => 'current')
+            );
+        }
+        else
+        {
+            $breadcrumbs = array(
+                array('url' => base_url('manage/users/showlist'), 'name' => lang('rr_userslist')),
+                array('url' => base_url('manage/users/show/'.$encoded_username.''), 'name' => html_escape($user->getUsername()),),
+                array('url' => base_url('#'), 'name' => lang('rr_changepass'), 'type' => 'current')
+            );
+        }
+        $data['breadcrumbs'] = $breadcrumbs;
         $data['encoded_username'] = $encoded_username;
         $data['manage_access'] = $manage_access;
         $data['write_access'] = $write_access;

--- a/application/controllers/smanage/Taskscheduler.php
+++ b/application/controllers/smanage/Taskscheduler.php
@@ -262,7 +262,7 @@ class Taskscheduler extends MY_Controller
             $lastRun = $t->getLastRun();
             $lastRunHtml = 'never';
             if (!empty($lastRun)) {
-                $lastRunHtml = date('Y-m-d H:i:s', $lastRun->format('U') + j_auth::$timeOffset);
+                $lastRunHtml = $lastRun->format('Y-m-d H:i:s');
 
             }
             $params = $t->getJparams();

--- a/application/language/english/rr_lang.php
+++ b/application/language/english/rr_lang.php
@@ -638,6 +638,7 @@ $lang['forSPpart']                  = 'for SP part';
 $lang['forIDPpart']                  = 'for IDP part';
 $lang['rr_resourceurl']             = 'Resource home URL';
 $lang['rr_geolocations_for']        = 'Geolocations for';
+$lang['rr_geo']                     = 'Geolocation';
 $lang['rr_bindingname']             = 'Binding Name';
 $lang['rr_addnewacs']               = 'Add new ACS';
 $lang['rr_reset']                   = 'Reset';
@@ -1186,6 +1187,7 @@ $lang['nosession']                 = 'No valid session. Please re-login!';
 $lang['entname_default_expl']              = 'This is default value for OrganizationName.<br /> If localized name is not set for English language then this value is used instead in generated SAML metadata: /EntityDescriptor/Organization/OrganizationName';
 $lang['entdisplname_default_expl']              = 'This is default value for OrganizationDisplayName.<br /> If localized name is not set for English language then this value is used instead in generated SAML metadata: /EntityDescriptor/Organization/OrganizationDisplayName.<br /> Also is used as default English lang in metadata: /EntityDescriptor/[IDPSSODescriptor|SPSSODescriptor]/Extensions/UIInfo/DisplayName';
 
+$lang['errmissssoaasrvs']         = 'At least one IDPSSODescriptor/SingleSignOn Service URL or/and  AttributeAuthorityDescriptor/AttributeService URL must be set';
 $lang['entregpolicy_expl']        = 'RegistrationPolicy is added to Metadata only if registrationAuthority is set.<br /> XPath in generated metadata: EntityDescriptor/Extensions/RegistrationInfo/RegistrationPolicy';
 $lang['fvalidatorjoinfed']        = 'Your Entity should pass Federation Validator(s) otherwise your request may be rejected';
 $lang['manValidator']             = 'Mandatory validator(s)';

--- a/application/libraries/Form_element.php
+++ b/application/libraries/Form_element.php
@@ -301,7 +301,7 @@ class Form_element
 		}
 
 		if (strcmp($enttype, 'SP') != 0) {
-			$Part = '<fieldset><legend>' . lang('idpcerts') . ' <small><i>IDPSSODesciptor</i></small></legend><div>';
+			$Part = '<fieldset><legend>IDPSSODescriptor</legend><div>';
 			$idpssocerts = array();
 // start CERTS IDPSSODescriptor
 			if ($sessform && isset($ses['crt']['idpsso'])) {
@@ -318,7 +318,7 @@ class Form_element
 			$Part .= $newelement . '</div></fieldset>';
 			$result[] = $Part;
 // end CERTS IDPSSODescriptor
-			$Part = '<fieldset><legend>' . lang('idpcerts') . ' <small><i>AttributeAuthorityDesciptor</i></small></legend><div>';
+			$Part = '<fieldset><legend>AttributeAuthorityDescriptor</legend><div>';
 			$aacerts = array();
 // start CERTS AttributeAuthorityDescriptor
 			if ($sessform && isset($ses['crt']['aa'])) {
@@ -338,7 +338,7 @@ class Form_element
 // end CERTS AttributeAuthorityDescriptor
 		}
 		if (strcmp($enttype, 'IDP') != 0) {
-			$Part = '<fieldset><legend>' . lang('rr_certificates') . ' <small><i>' . lang('serviceprovider') . '</i></small></legend><div>';
+			$Part = '<fieldset><legend>SPSSODescriptor</legend><div>';
 			$spssocerts = array();
 			if ($sessform && isset($ses['crt']['spsso'])) {
 				foreach ($ses['crt']['spsso'] as $key => $value) {
@@ -360,9 +360,7 @@ class Form_element
 	private function _generateAttrReqAddButton($attrs)
 	{
 
-		$r = '<div class="small-12 columns">';
-		$r .= '<div class="medium-3 columns">';
-		$r .= '<select name="nattrreq">';
+		$r = '<div class="small-12 columns"><div class="medium-3 columns"><select name="nattrreq">';
 		foreach ($attrs as $a) {
 			if (isset($a['disabled'])) {
 				$disabled = 'disabled="disabled"';
@@ -371,11 +369,7 @@ class Form_element
 			}
 			$r .= '<option value="' . $a['attrid'] . '" ' . $disabled . '>' . $a['attrname'] . '</option>';
 		}
-
-		$r .= '</select>';
-		$r .= '</div>';
-		$r .= '<div class="medium-3 columns end"><button id="nattrreqbtn" name="nattrreqbtn" class="tiny">' . lang('rr_add') . '</button></div>';
-		$r .= '</div>';
+		$r .= '</select></div><div class="medium-3 columns end"><button id="nattrreqbtn" name="nattrreqbtn" class="tiny">'.lang('rr_add').'</button></div></div>';
 		return $r;
 	}
 

--- a/application/views/manage/password_change_view.php
+++ b/application/views/manage/password_change_view.php
@@ -1,37 +1,53 @@
 <?php
 
 $errors_v = validation_errors('<span class="span-12">', '</span><br />');
-if (!empty($errors_v))
-{
-    echo '<div data-alert class="small-12 medium-10 large-8 small-centered columns alert-box alert">';
+
+if (!empty($errors_v)) {
+    echo '<div data-alert class="small-12 column alert-box alert">';
     echo $errors_v;
     echo '</div>';
 }
-if (!empty($message))
-{
-    echo '<div data-alert class="small-12 medium-10 large-8 small-centered columns alert-box success">' . $message . '</div>';
+
+
+if (!empty($message)) {
+    echo '<div data-alert class="small-12 columns alert-box success">' . $message . '</div>';
+    $redirectto = base_url('manage/users/show/'.$encoded_username.'');
+    ?>
+    <script type="text/javascript">
+        function Redirect() {
+            window.location.href = "<?php echo $redirectto;?>";
+        }
+        setTimeout('Redirect()', 1000);
+    </script>
+<?php
 }
 
-$form_attributes = array('id' => 'formver2', 'class' => 'register');
-$action = base_url() . "manage/users/passedit/" . $encoded_username;
-echo form_open($action, $form_attributes);
+else {
 
-if ($write_access && !$manage_access)
-{
+    $form_attributes = array('id' => 'formver2', 'class' => 'register');
+    $action = base_url() . "manage/users/passedit/" . $encoded_username;
+    echo form_open($action, $form_attributes);
+
+    if ($write_access && !$manage_access) {
+        echo '<div class="small-12 columns">';
+        echo '<div class="medium-3 columns">' . jform_label('Current password', 'oldpassword') . '</div>';
+        echo '<div class="medium-6 columns end">' . form_password('oldpassword') . '</div>';
+        echo '</div>';
+    }
     echo '<div class="small-12 columns">';
-    echo '<div class="small-3 columns">' . jform_label('Current password', 'oldpassword') . '</div>';
-    echo '<div class="small-6 large-6 columns end">' . form_password('oldpassword') . '</div>';
+    echo '<div class="medium-3 columns medium-text-right"><label for="password" class="inline">' . lang('rr_npassword') . '</label></div>';
+    echo '<div class="medium-6 columns end">' . form_password('password') . '</div>';
     echo '</div>';
+    echo '<div class="small-12 columns">';
+    echo '<div class="medium-3 columns medium-text-right"><label for="passwordconf" class="inline">' . lang('rr_npasswordconf') . '</label></div>';
+    echo '<div class="medium-6 columns end">' . form_password('passwordconf') . '</div>';
+    echo '</div>';
+    echo '<div class="buttons small-12 columns text-right">';
+    echo '<div class="medium-9 columns "><button type="submit"  name="submit", value="submit" class="button savebutton saveicon">' . lang('rr_changepass') . '</button></div>';
+    echo '</div>';
+    echo form_close();
+
 }
-echo '<div class="small-12 columns">';
-echo '<div class="small-3 columns">' . jform_label(lang('rr_npassword'), 'password') . '</div>';
-echo '<div class="small-6 large-6 columns end">' . form_password('password') . '</div>';
-echo '</div>';
-echo '<div class="small-12 columns">';
-echo '<div class="small-3 columns">' . jform_label(lang('rr_npasswordconf'), 'passwordconf') . '</div>';
-echo '<div class="small-6 large-6 columns end">' . form_password('passwordconf') . '</div>';
-echo '</div>';
-echo '<div class="buttons small-12 columns text-right">';
-echo '<div class="small-9 columns "><button type="submit"  name="submit", value="submit" class="button savebutton saveicon">' . lang('rr_changepass') . '</button></div>';
-echo '</div>';
-echo form_close();
+
+
+


### PR DESCRIPTION
1) added: allow to generate metadata for entity with only AttributeAuthorityDescriptor role set - but:
  SAML spec doesn't require certificate to be set for Role but Jagger does - so to allow generate : 
 a) IDPSSODescriptor part in metadata you need to have at  leas one SingleSignOn url and certificate set
 b) AttributeAuthorityDescriptor part in metadata you need to have at  leas one AttributeService url and certificate set

 c)  SPSSODescriptor - jagger doesn require certificate to be set

2) some code cleaning

@todo hide IdentityProviders who have only  AttributeAuthorityDescriptor role from wayf list
