### PR TITLE
Develop

### DIFF
--- a/application/controllers/manage/Importer.php
+++ b/application/controllers/manage/Importer.php
@@ -247,7 +247,7 @@ class Importer extends MY_Controller
         );
         $this->xmlbody = $this->curl->simple_get('' . $metadataurl . '', array(), $curloptions);
         if (empty($this->xmlbody)) {
-            $this->otherErrors[] = $this->curl->debug();
+            $this->otherErrors[] = html_escape($this->curl->error_string);
             return false;
         }
         libxml_use_internal_errors(true);

--- a/application/libraries/Metadata2array.php
+++ b/application/libraries/Metadata2array.php
@@ -30,6 +30,7 @@ class Metadata2array
     private $nameidsattrs = array();
     private $newNameSpaces = array();
     protected $ci;
+    protected $convertNameIdToAttrs;
     protected $allowedEntcats = array();
     /**
      * @var Doctrine\ORM\EntityManager $em
@@ -44,6 +45,13 @@ class Metadata2array
     public function __construct() {
         $this->ci = &get_instance();
         $this->em = $this->ci->doctrine->em;
+        $cnfConvertNameIdsToAttrs = $this->ci->config->item('importnameidstoattrs');
+        $this->convertNameIdToAttrs = true;
+        if($cnfConvertNameIdsToAttrs === false){
+            $this->convertNameIdToAttrs = false;
+        }
+
+
         $this->i = 0;
         $this->occurance = array();
         $this->metaArray = array();
@@ -277,7 +285,7 @@ class Metadata2array
             $entity['type'] = 'SP';
         }
 
-        if ($isSp) {
+        if ($this->convertNameIdToAttrs && $isSp) {
             if (isset($entity['details']['spssodescriptor']['nameid']) && is_array($entity['details']['spssodescriptor']['nameid']) && count($entity['details']['spssodescriptor']['nameid']) > 0) {
                 if (in_array('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent', $entity['details']['spssodescriptor']['nameid']) && array_key_exists('persistentId', $this->nameidsattrs)) {
                     $entity['details']['reqattrs'][] = array('name' => $this->nameidsattrs['persistentId'], 'req' => 'True');

--- a/application/models/Provider.php
+++ b/application/models/Provider.php
@@ -2413,7 +2413,7 @@ class Provider
                 }
             }
         }
-        if ($full && !empty($a['algs'])) {
+        if (!empty($a['algs'])) {
 
             foreach ($a['algs'] as $alg) {
                 $e = new ExtendMetadata();


### PR DESCRIPTION
- closes #246
  
  now you should be able iport/sync metadata with non-standard prefixes
- by default importing/sync metadata converted nameids like transientId, email into requested attributes (historical reason - used to generate arp)
  As some might not like it I added condition so if you don't want such functionality please
  add below line into  config_rr.php file
  
  `$config['importnameidstoattrs'] = false;`
