### PR TITLE
Create variable for customizing the minimal length of a federation name

### DIFF
--- a/application/config/config_rr-default.php
+++ b/application/config/config_rr-default.php
@@ -11,6 +11,11 @@ $config['syncpass'] = 'verystrongpasss';
 
 $config['support_mailto'] = 'support@example.com';
 
+/**
+ * Federation Registration
+**/
+$config['fedname_min_length'] = 5
+
 
 /**
  * if TRUE feadmin may remove member from his fed without approve queue

--- a/application/controllers/federations/Fedregistration.php
+++ b/application/controllers/federations/Fedregistration.php
@@ -126,8 +126,9 @@ class Fedregistration extends MY_Controller
     }
 
     private function _submit_validate() {
-        $this->form_validation->set_rules('fedname', lang('rr_fed_name'), 'required|min_length[5]|max_length[128]|xss_clean|federation_unique[name]');
-        $this->form_validation->set_rules('fedsysname', lang('rr_fed_sysname'), 'required|min_length[5]|max_length[128]|alpha_dash|xss_clean|federation_unique[sysname]');
+        $fednameMinLength = $this->config->item('fedname_min_length') ?: 5;
+        $this->form_validation->set_rules('fedname', lang('rr_fed_name'), 'required|min_length[' . $fednameMinLength . ']|max_length[128]|xss_clean|federation_unique[name]');
+        $this->form_validation->set_rules('fedsysname', lang('rr_fed_sysname'), 'required|[' . $fednameMinLength . ']|max_length[128]|alpha_dash|xss_clean|federation_unique[sysname]');
         $this->form_validation->set_rules('fedurn', lang('fednameinmeta'), 'required|min_length[5]|max_length[128]|xss_clean|federation_unique[uri]');
         $this->form_validation->set_rules('description', lang('rr_fed_desc'), 'min_length[5]|max_length[500]|xss_clean');
         $this->form_validation->set_rules('termsofuse', lang('rr_fed_tou'), 'min_length[5]|max_length[1000]|xss_clean');

--- a/application/controllers/federations/Fedregistration.php
+++ b/application/controllers/federations/Fedregistration.php
@@ -128,7 +128,7 @@ class Fedregistration extends MY_Controller
     private function _submit_validate() {
         $fednameMinLength = $this->config->item('fedname_min_length') ?: 5;
         $this->form_validation->set_rules('fedname', lang('rr_fed_name'), 'required|min_length[' . $fednameMinLength . ']|max_length[128]|xss_clean|federation_unique[name]');
-        $this->form_validation->set_rules('fedsysname', lang('rr_fed_sysname'), 'required|[' . $fednameMinLength . ']|max_length[128]|alpha_dash|xss_clean|federation_unique[sysname]');
+        $this->form_validation->set_rules('fedsysname', lang('rr_fed_sysname'), 'required|min_length[' . $fednameMinLength . ']|max_length[128]|alpha_dash|xss_clean|federation_unique[sysname]');
         $this->form_validation->set_rules('fedurn', lang('fednameinmeta'), 'required|min_length[5]|max_length[128]|xss_clean|federation_unique[uri]');
         $this->form_validation->set_rules('description', lang('rr_fed_desc'), 'min_length[5]|max_length[500]|xss_clean');
         $this->form_validation->set_rules('termsofuse', lang('rr_fed_tou'), 'min_length[5]|max_length[1000]|xss_clean');


### PR DESCRIPTION
One of our users wanted to created a federation called RIF. Unfortunately this was not possible, as the minimum federation name length is 5. 

This PR gives the admin to decide himself what the min_length of a fedname should be.
