### PR TITLE
mysql encrypted connection, charset

### DIFF
--- a/application/config/database-default.php
+++ b/application/config/database-default.php
@@ -67,11 +67,11 @@ $db['default']['stricton'] = FALSE;
 /**
  * for mysql ssl connection
  */
-/*$db['default']['ssl'] = true;
-$db['default']['ssl_ca'] = "ca location";
-$db['default']['ssl_key'] = "key path";
-$db['default']['ssl_cert'] = "cet path";
-$db['default']['ssl_verify'] = false;*/
+/*
+$db['default']['encrypt']['ssl_ca'] = "ca location";
+$db['default']['encrypt']['ssl_key'] = "key path";
+$db['default']['encrypt']['ssl_cert'] = "cet path";
+$db['default']['encrypt']['ssl_verify'] = false;*/
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/config/database-default.php
+++ b/application/config/database-default.php
@@ -64,6 +64,14 @@ $db['default']['swap_pre'] = '';
 $db['default']['autoinit'] = TRUE;
 $db['default']['stricton'] = FALSE;
 
+/**
+ * for mysql ssl connection
+ */
+/*$db['default']['ssl'] = true;
+$db['default']['ssl_ca'] = "ca location";
+$db['default']['ssl_key'] = "key path";
+$db['default']['ssl_cert'] = "cet path";
+$db['default']['ssl_verify'] = false;*/
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/config/database-default.php
+++ b/application/config/database-default.php
@@ -68,6 +68,8 @@ $db['default']['stricton'] = FALSE;
  * for mysql ssl connection
  */
 /*
+ *
+$db['default']['ssl'] = true;
 $db['default']['encrypt']['ssl_ca'] = "ca location";
 $db['default']['encrypt']['ssl_key'] = "key path";
 $db['default']['encrypt']['ssl_cert'] = "cet path";

--- a/application/libraries/Doctrine.php
+++ b/application/libraries/Doctrine.php
@@ -109,12 +109,12 @@ class Doctrine
         }
         if ($dbriver === 'pdo_mysql') {
 
-            if (array_key_exists('ssl', $dbconfig) && ($dbconfig['ssl'] === true || strtolower($dbconfig['ssl']) === 'true')) {
+            if (isset($dbconfig['encrypt'])) {
                 $connectionOptions['driverOptions'] = array(
-                    PDO::MYSQL_ATTR_SSL_CA => $dbconfig['ssl_ca'],
-                    PDO::MYSQL_ATTR_SSL_KEY => $dbconfig['ssl_key'],
-                    PDO::MYSQL_ATTR_SSL_CERT => $dbconfig['ssl_cert'],
-                    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => $dbconfig['ssl_verify']
+                    PDO::MYSQL_ATTR_SSL_CA => $dbconfig['encrypt']['ssl_ca'],
+                    PDO::MYSQL_ATTR_SSL_KEY => $dbconfig['encrypt']['ssl_key'],
+                    PDO::MYSQL_ATTR_SSL_CERT => $dbconfig['encrypt']['ssl_cert'],
+                    PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => $dbconfig['encrypt']['ssl_verify']
                 );
             }
             $charset = $dbconfig['char_set'] ?: 'latin1';

--- a/application/libraries/Doctrine.php
+++ b/application/libraries/Doctrine.php
@@ -117,8 +117,10 @@ class Doctrine
                     PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => $dbconfig['encrypt']['ssl_verify']
                 );
             }
-            $charset = $dbconfig['char_set'] ?: 'latin1';
-            $connectionOptions['driverOptions']['' . PDO::MYSQL_ATTR_INIT_COMMAND . ''] = 'SET NAMES ' . $charset . '';
+            if(array_key_exists('char_set',$dbconfig)){
+                $connectionOptions['driverOptions']['' . PDO::MYSQL_ATTR_INIT_COMMAND . ''] = 'SET NAMES ' . $dbconfig['char_set'] . '';
+            }
+
 
         }
 

--- a/application/libraries/Doctrine.php
+++ b/application/libraries/Doctrine.php
@@ -109,7 +109,7 @@ class Doctrine
         }
         if ($dbriver === 'pdo_mysql') {
 
-            if (isset($dbconfig['encrypt'])) {
+            if (array_key_exists('ssl',$dbconfig) && ($dbconfig['ssl'] === true  || $dbconfig['ssl'] === 'true' ) && isset($dbconfig['encrypt'])) {
                 $connectionOptions['driverOptions'] = array(
                     PDO::MYSQL_ATTR_SSL_CA => $dbconfig['encrypt']['ssl_ca'],
                     PDO::MYSQL_ATTR_SSL_KEY => $dbconfig['encrypt']['ssl_key'],


### PR DESCRIPTION
- added support for mysql encrypted connection in doctrine connector:
to enable it update database.php in config folder - sample:
```php
$db['default']['ssl'] = true;
$db['default']['encrypt']['ssl_ca'] = "ca location";
$db['default']['encrypt']['ssl_key'] = "key path";
$db['default']['encrypt']['ssl_cert'] = "cet path";
$db['default']['encrypt']['ssl_verify'] = false;
```
**_Note_**  migration (URI: smanage/reports -> option  "Check and run data upgrade/migration if needed") is using native CI db driver and it doesn't support ssl_verify (PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT) . 

- doctrine now loads $db['default']['char_set']  
**_Be careful if you already have an existing db with data - if you don't know what charset to set then delete above option from database.php config file_**