### PR TITLE
do_hash() replaced with PHP's native hash()

### DIFF
--- a/application/libraries/J_cache.php
+++ b/application/libraries/J_cache.php
@@ -105,7 +105,7 @@ class J_cache
 		// Clean given arguments to a 0-index array
 		$arguments = array_values($arguments);
 
-		$cache_file = $property.DIRECTORY_SEPARATOR.do_hash($method.serialize($arguments), 'sha1');
+		$cache_file = $property.DIRECTORY_SEPARATOR.hash('sha1', $method.serialize($arguments));
 
 		// See if we have this cached or delete if $expires is negative
 		if($expires >= 0)


### PR DESCRIPTION
Replacing the use of CodeIgniter's do_hash() function with PHP's native hash() function call. CodeIgniter's do_hash() is using PHP's native hash() from version 3.0.0. CodeIgniter has completely removed function do_hash() in version 3.2.0.