### PR TITLE
createdAt date format patch

### DIFF
--- a/application/models/Invitation.php
+++ b/application/models/Invitation.php
@@ -234,7 +234,7 @@ class Invitation
      */
     public function doStuffOnPrePersist()
     {
-        $this->createdAt = date('Y-m-d H:m:s');
+        $this->createdAt = date('Y-m-d H:i:s');
         if ($this->validto === null) {
             $oneDay = time() + (24 * 60 * 60);
             $this->validto = $oneDay;

--- a/application/models/Queue.php
+++ b/application/models/Queue.php
@@ -124,7 +124,7 @@ class Queue {
      * @PrePersist 
      */
     public function doStuffOnPrePersist() {
-        $this->createdAt = date('Y-m-d H:m:s');
+        $this->createdAt = date('Y-m-d H:i:s');
     }
 
     public function inviteProvider($obj)


### PR DESCRIPTION
For the createdAt variable in `Invitation.php` and `Queue.php`, `m` format character used instead of `i`  for minutes value. "Created At" dates were using the following format: `Year-month-date Hour:month:seconds`.

In PHP DateTime:
- `m` used for numeric representation for month
- `i` used for minutes with leading zeros

Replaced month format character to minutes character in within the time format.