### PR TITLE
fix sync/import metadata containing not common ns declarations in root

### DIFF
--- a/application/helpers/metadata_elements_helper.php
+++ b/application/helpers/metadata_elements_helper.php
@@ -123,7 +123,6 @@ function h_metadataNamespaces()
 		'xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
 		'xi' => 'http://www.w3.org/2001/XInclude',
                 'alg' => 'urn:oasis:names:tc:SAML:metadata:algsupport',
-                'algsupport' => 'urn:oasis:names:tc:SAML:metadata:algsupport',
                 'remd' => 'http://refeds.org/metadata',
                 'hoksso' => 'urn:oasis:names:tc:SAML:2.0:profiles:holder-of-key:SSO:browser'
 	);

--- a/application/libraries/Metadata2array.php
+++ b/application/libraries/Metadata2array.php
@@ -165,12 +165,27 @@ class Metadata2array
 
     private function entityConvert(\DOMElement $node, $full = false) {
 
+        /**
+         * @var \DOMDocument $tmpEntityDomDoc
+         */
+        $tmpEntityDomDoc = new \DOMDocument();
+        $tmpEntityDomDoc->loadXML('<md:EntitiesDescriptor></md:EntitiesDescriptor>');
+        $tmpEntityXpath = new \DOMXPath(($tmpEntityDomDoc));
+        $tmpNamespaces = h_metadataNamespaces();
+        foreach ($tmpNamespaces as $key => $value) {
+            $tmpEntityXpath->registerNamespace($key, $value);
+        }
+        $tmpNode = $tmpEntityDomDoc->importNode($node, true);
+        $tmpEntityDomDoc->documentElement->appendChild($tmpNode);
+
+
+
         $isIdp = false;
         $isSp = false;
         $entity = array(
             'metadata' => null,
-            'entityid' => $node->getAttribute('entityID'),
-            'validuntil' => $node->getAttribute('validUntil'),
+            'entityid' => $tmpNode->getAttribute('entityID'),
+            'validuntil' => $tmpNode->getAttribute('validUntil'),
             'rigistrar' => null,
             'regdate' => null,
             'coc' => array(),
@@ -184,7 +199,7 @@ class Metadata2array
             ),
         );
 
-        foreach ($node->childNodes as $gnode) {
+        foreach ($tmpNode->childNodes as $gnode) {
 
             if ($gnode->localName === 'IDPSSODescriptor') {
                 $isIdp = true;
@@ -312,7 +327,7 @@ class Metadata2array
         }
 
         try {
-            $entity['metadata'] = $this->doc->saveXML($node);
+            $entity['metadata'] = $tmpEntityDomDoc->saveXML($tmpNode);
         } catch (Exception $e) {
             log_message('warning', 'Couldnt store xml: ' . $e);
         }


### PR DESCRIPTION
fix issue when sync/import metadata with namespaces not supported by jagger and such namespaces where declared in root (like edugain metadata). later they were missed during generating metadata by jagger producing invalid metadata.