### PR TITLE
Update Zacl.php

### DIFF
--- a/application/libraries/Zacl.php
+++ b/application/libraries/Zacl.php
@@ -327,7 +327,7 @@ class Zacl
         }
     }
 
-    public function addAccessToUserByFedadmin($federationID = null, $resource, $action, $user, $group, $resource_type = null) {
+    public function addAccessToUserByFedadmin($federationID, $resource, $action, $user, $group, $resource_type = null) {
         $roleExists = $this->acl->hasRole('selected_user');
         if ($roleExists) {
             $this->acl->removeRole('selected_user');


### PR DESCRIPTION
Solution for:

Deprecated: Optional parameter $federationID declared before required parameter $group is implicitly treated as a required parameter in /opt/rr3/application/libraries/Zacl.php on line 330