### PR TITLE
Update Contact.php

### DIFF
--- a/application/models/Contact.php
+++ b/application/models/Contact.php
@@ -75,26 +75,26 @@ class Contact
     }
 
     public function setSurName($name) {
-        $this->surname = trim($name);
+        $this->surname = trim($name ?? '');
 
         return $this;
     }
 
     public function setGivenName($name) {
-        $this->givenname = trim($name);
+        $this->givenname = trim($name ?? '');
 
         return $this;
     }
 
     public function setEmail($mail) {
         $mail = str_replace('mailto:', '', $mail);
-        $this->email = trim($mail);
+        $this->email = trim($mail ?? '');
 
         return $this;
     }
 
     public function setPhone($phone) {
-        $this->phone = trim($phone);
+        $this->phone = trim($phone ?? '');
 
         return $this;
     }


### PR DESCRIPTION
Solution for PHP 8.1:

Message: trim(): Passing null to parameter #1 ($string) of type string is deprecated

Filename: models/Contact.php

Line Number: 97